### PR TITLE
Add options for starting in GUI or CLI modes

### DIFF
--- a/scruml/__init__.py
+++ b/scruml/__init__.py
@@ -1,12 +1,26 @@
 # ScrUML
 # __init__.py
 # Team JJARS
+import sys
+from typing import List
+
 from scruml import uml_context_cli
+from scruml import uml_context_gui
 
 
-def main() -> None:
+def main(argv: List[str] = sys.argv) -> None:
     """Act as primary entry point for the program."""
-    uml_context_cli.activate()
+    if len(argv) == 1 or (len(argv) == 2 and argv[1] == "--gui"):
+        # If no arguments were passed or "--gui" was specified, run in GUI mode
+        uml_context_gui.activate()
+    elif len(argv) == 2 and argv[1] == "--cli":
+        # If "--cli" was specified, run in CLI mode
+        uml_context_cli.activate()
+    else:
+        print("usage: scruml [--gui | --cli]\n")
+        print("Options:")
+        print("--gui\t: run ScrUML in graphical user interface mode")
+        print("--cli\t: run ScrUML in command line interface mode")
 
 
 # If this file was loaded explicitly, run main()

--- a/scruml/__main__.py
+++ b/scruml/__main__.py
@@ -1,7 +1,9 @@
 # ScrUML
 # main.py
 # Team JJARS
+import sys
+
 import scruml
 
 # Run main()
-scruml.main()
+scruml.main(sys.argv)

--- a/scruml/uml_context_gui.py
+++ b/scruml/uml_context_gui.py
@@ -1,0 +1,7 @@
+# ScruML
+# uml_context_gui.py
+# Team JJARS
+
+
+def activate() -> None:
+    print("GUI coming soon!")


### PR DESCRIPTION
This will add options for starting ScrUML in GUI or CLI modes. Also adds the mostly empty file uml_context_gui.py. This addresses issue #29.