### PR TITLE
Relationship refactor cleanup

### DIFF
--- a/scruml/assets/diagram.js
+++ b/scruml/assets/diagram.js
@@ -169,16 +169,7 @@ class Diagram {
 
         // Build element on the canvas with appropriate ID and classification
         var element = this.canvas.nested().id(className).addClass("uml-class");
-        // Hardcoded class members (comment out body of updateClassAttr() when you uncomment this)
-        /*
-        var tempClassAttr = { "[F:getID]": "[public][string][int][offset][double][modifier]",
-                                           "[F:getVal]": "[private][double][string][prefix]",
-                                           "[F:calculateDist]": "[protected][int]",
-                                           "[V:myVar]": "[public][string]",
-                                           "[V:m_volume]": "[protected][float]",
-                                           "[V:m_distance]": "[private][int]" };
-        element.attr('data-attributes', JSON.stringify(tempClassAttr));
-        */
+
         element.attr('data-attributes', JSON.stringify(classAttr))
 
         // Add body and text

--- a/scruml/assets/scruml.js
+++ b/scruml/assets/scruml.js
@@ -139,14 +139,7 @@ function classElementConnect(element)
     var classBName = element.id();
     diagram.clearSelection();
 
-    var relationshipName = prompt("Enter the relationship name (leave blank for no name):");
-
-    // If the user hit "cancel", return
-    if (relationshipName == null) return;
-
-    pywebview.api.addRelationship({"class_name_a": classAName,
-                                   "class_name_b": classBName,
-                                   "relationship_name": relationshipName}).then(function addRelationshipUpdate(response) {
+    pywebview.api.addRelationship({"class_name_a": classAName, "class_name_b": classBName}).then(function addRelationshipUpdate(response) {
                                        if (response !== "")
                                        {
                                            alert(response);

--- a/scruml/uml_context_cli.py
+++ b/scruml/uml_context_cli.py
@@ -177,6 +177,11 @@ For help with identifiers, type in 'help identifiers'"""
             print("Class '{}' does not exist in the diagram".format(rel_id[1]))
             return
 
+        # Check if both args are the same class, no class can have a relationship with itself
+        if rel_id[0] == rel_id[1]:
+            print("A class cannot have a relationship with itself.")
+            return
+
         # Add the relationship to the diagram, checking for an error
         if not self.__diagram.add_relationship(rel_id[0], rel_id[1]):
             print(

--- a/scruml/uml_context_gui.py
+++ b/scruml/uml_context_gui.py
@@ -277,6 +277,8 @@ Structure: dictionary[classPair][attributeName] == attributeValue"""
             return "Class " + class_name_a + " not found in the diagram."
         if not class_name_b in self.__diagram.get_all_class_names():
             return "Class " + class_name_b + " not found in the diagram."
+        if class_name_a == class_name_b:
+            return "A class cannot have a relationship with itself."
 
         if not self.__diagram.add_relationship(class_name_a, class_name_b):
             return "Relationship already exists: {}".format(


### PR DESCRIPTION
This merge will add error messages for the CLI & GUI when the user tries to add a relationship with a class to itself.

Additionally, this merge removes the prompt for a relationship name when creating a relationship in the GUI.

This merge does some minor clean-up for diagram.js: the commented out code (hardcoded test values) has been removed.

Once merged, issue #116 will be resolved.